### PR TITLE
Add GitHub Skills activity to signup list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,12 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of the GitHub Certifications program. Time-sensitive registration!",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the missing 'GitHub Skills' activity to the activities signup list, addressing the urgent issue for student registration and participation in the new GitHub Certifications program.